### PR TITLE
Making the gem compatible with activemodel ~4

### DIFF
--- a/lib/bitstamp/model.rb
+++ b/lib/bitstamp/model.rb
@@ -2,16 +2,12 @@ module Bitstamp
   class Model
     attr_accessor :error, :message
 
-    if ActiveModel::VERSION::MAJOR <= 3
-      include ActiveModel::Validations
-      include ActiveModel::Conversion
-      extend ActiveModel::Naming
+    include ActiveModel::Validations
+    include ActiveModel::Conversion
+    extend ActiveModel::Naming
 
-      def initialize(attributes = {})
-        self.attributes = attributes
-      end
-    else
-      include ActiveModel::Model
+    def initialize(attributes = {})
+      self.attributes = attributes
     end
 
     # Set the attributes based on the given hash


### PR DESCRIPTION
I'm updating an application which uses your API from rails 3 to rails 4.
I was stumbling on a error when I tried to use Bitstamp.ticker

This error:

``` ruby
NoMethodError: undefined method `vwap=' for #<Bitstamp::Ticker:0x007f885d4df070>
```

In this PR I'm sending my commits which solved this error. I ran your tests against activemodel/activesupport ~> 4 and activemodel/activesupport ~> 3.1 and they all passed.

Best regards.
